### PR TITLE
Empty email attributes should dump to the database as `nil`, not `""`.

### DIFF
--- a/lib/email_attribute/list.rb
+++ b/lib/email_attribute/list.rb
@@ -35,7 +35,7 @@ module EmailAttribute
 
     class << self
       def dump(email_address)
-        return nil if email_address.nil?
+        return nil if email_address.blank?
 
         email_address.to_s
       end

--- a/lib/email_attribute/single_address.rb
+++ b/lib/email_attribute/single_address.rb
@@ -18,7 +18,7 @@ module EmailAttribute
 
     class << self
       def dump(email_address)
-        return nil if email_address.nil?
+        return nil if email_address.blank?
 
         email_address.to_s
       end

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -33,6 +33,17 @@ class ListTest < ActiveSupport::TestCase
       assert_equal("", list.to_s)
     end
 
+    should "dump empty values as nil" do
+      list = EmailAttribute::List.new(nil)
+      assert_nil(EmailAttribute::List.dump(list))
+    end
+
+    should "load nil values as empty lists" do
+      list = EmailAttribute::List.load(nil)
+      assert_equal(0, list.length)
+      assert_equal("", list.to_s)
+    end
+
     should "handle array values" do
       list = EmailAttribute::List.new(["foo@bar.com", "blah@blabber.com"])
       assert_equal(2, list.length)

--- a/test/unit/single_address_test.rb
+++ b/test/unit/single_address_test.rb
@@ -29,14 +29,13 @@ class SingleAddressTest < ActiveSupport::TestCase
     end
 
     should "dump empty values as nil" do
-      list = EmailAttribute::SingleAddress.new(nil)
-      assert_nil(EmailAttribute::SingleAddress.dump(list))
+      single = EmailAttribute::SingleAddress.new(nil)
+      assert_nil(EmailAttribute::SingleAddress.dump(single))
     end
 
-    should "load nil values as empty lists" do
-      list = EmailAttribute::SingleAddress.load(nil)
-      assert_equal(0, list.length)
-      assert_equal("", list.to_s)
+    should "load nil values as empty addresses" do
+      single = EmailAttribute::SingleAddress.load(nil)
+      assert_equal("", single)
     end
     
     should 'responds to strip for strip_attributes gem' do

--- a/test/unit/single_address_test.rb
+++ b/test/unit/single_address_test.rb
@@ -28,6 +28,17 @@ class SingleAddressTest < ActiveSupport::TestCase
       assert_equal("", single)
     end
 
+    should "dump empty values as nil" do
+      list = EmailAttribute::SingleAddress.new(nil)
+      assert_nil(EmailAttribute::SingleAddress.dump(list))
+    end
+
+    should "load nil values as empty lists" do
+      list = EmailAttribute::SingleAddress.load(nil)
+      assert_equal(0, list.length)
+      assert_equal("", list.to_s)
+    end
+    
     should 'responds to strip for strip_attributes gem' do
       single = EmailAttribute::SingleAddress.new(' foo@bar.com ')
       assert_equal 'foo@bar.com', single.strip


### PR DESCRIPTION
It doesn't make much sense to have empty strings all over our DB, so
blank attributes should be NULL in the DB. They can still turn into an
email address / list on their way back out.
